### PR TITLE
fix: Refresh token & Access Token을 활용한 자동 로그인 방식

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "express": "^4.17.3",
                 "inko": "^1.1.1",
                 "jsonwebtoken": "^8.5.1",
+                "jwt-decode": "^3.1.2",
                 "method-override": "^3.0.0",
                 "multer": "^1.4.5-lts.1",
                 "multer-s3": "^2.10.0",
@@ -2004,6 +2005,11 @@
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "node_modules/jwt-decode": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+            "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
         },
         "node_modules/keyv": {
             "version": "3.1.0",
@@ -5163,6 +5169,11 @@
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "jwt-decode": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+            "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
         },
         "keyv": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "express": "^4.17.3",
         "inko": "^1.1.1",
         "jsonwebtoken": "^8.5.1",
+        "jwt-decode": "^3.1.2",
         "method-override": "^3.0.0",
         "multer": "^1.4.5-lts.1",
         "multer-s3": "^2.10.0",

--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -70,7 +70,7 @@ exports.checkToken = async function (req, res){
     if(!token)
         return res.send(response.response(baseResponse.TOKEN_EMPTY))
     
-    const checkTokenkResponse = await userProvider.checkToken(email);
+    const checkTokenkResponse = await userProvider.checkToken(email, exp, iat);
 
     return res.send(checkTokenkResponse)
 }

--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -63,14 +63,10 @@ exports.signinUser = async function (req, res){
 exports.checkToken = async function (req, res){
     const token = req.verifiedToken;
 
-    const email = token.userEmail;
-    const exp = token.exp;
-    const iat = token.iat;
-
     if(!token)
         return res.send(response.response(baseResponse.TOKEN_EMPTY))
     
-    const checkTokenkResponse = await userProvider.checkToken(email, exp, iat);
+    const checkTokenkResponse = await userProvider.checkToken(token);
 
     return res.send(checkTokenkResponse)
 }

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -86,19 +86,16 @@ async function checkToken(connection, email){
 }
 
 //refresh Token 조희
-async function refreshCheck(connection, refreshToken, email,  exp, iat){
+async function refreshCheck(connection, refreshToken, email){
   const refreshCheckQuery = `
-    SELECT COUNT(id) AS IS_EXIST
-    FROM RefreshToken
-    WHERE email = '${email}' AND refreshToken = '${refreshToken}'
-
+    SELECT RT.refreshToken As refreshToken, User.id, User.createdAt, name, User.email, generation, member, state
+    FROM RefreshToken AS RT INNER JOIN User On RT.email = User.email
+    WHERE RT.email = '${email}' AND refreshToken = '${refreshToken}'
     `
-  //console.log(refreshCheckQuery)
   
   const refreshCheckRow = await connection.query(refreshCheckQuery);
-  //console.log(refreshCheckRow[0])
 
-  return refreshCheckRow[0];
+  return refreshCheckRow[0][0];
 }
 
 module.exports = {

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -26,16 +26,15 @@ async function insertUserInfo(connection, insertUserInfoParams) {
 //유저 로그인
 async function signinUser(connection, signinUserParams){
   const signinUserQuery =`
-    select COUNT(email)
-    from User
-    WHERE email = ? AND password = ?;
+    SELECT id, createdAt, updatedAt, name, email, generation, member, state
+    FROM User
+    WHERE email = ? AND password = ? AND state = 'A';
   `
   const signinUserRow = await connection.query(
     signinUserQuery,
     signinUserParams
   )
-
-  return signinUserRow;
+  return signinUserRow[0][0];
 }
 
 //Refresh Token 저장
@@ -83,18 +82,21 @@ async function checkToken(connection, email){
   `
   const checkUserByEmailRow = await connection.query(getUserByEmail);
 
-  return checkUserByEmailRow[0];
+  return checkUserByEmailRow[0][0];
 }
 
 //refresh Token 조희
-async function refreshCheck(connection, refreshToken, email){
+async function refreshCheck(connection, refreshToken, email,  exp, iat){
   const refreshCheckQuery = `
     SELECT COUNT(id) AS IS_EXIST
     FROM RefreshToken
     WHERE email = '${email}' AND refreshToken = '${refreshToken}'
-  `
 
+    `
+  //console.log(refreshCheckQuery)
+  
   const refreshCheckRow = await connection.query(refreshCheckQuery);
+  //console.log(refreshCheckRow[0])
 
   return refreshCheckRow[0];
 }

--- a/src/app/User/userProvider.js
+++ b/src/app/User/userProvider.js
@@ -22,17 +22,23 @@ exports.emailDuplicateCheck = async function (email) {
   return emailCheckResult;
 }
 
-exports.checkToken = async function(email, exp, iat){
+exports.checkToken = async function(token){
   try{
     
     // const connection = await pool.getConnection(async (conn) => conn);
     // const checkTokenResult = await userDao.checkToken(connection, email);
     // connection.release();
-
-    let checkTokenResult = new Object;
-
+    
+    let checkTokenResult = new Object();
+    
     checkTokenResult.result = "available";
-    checkTokenResult.exp = exp;
+    checkTokenResult.exp = token.exp;
+    checkTokenResult.id = token.id,
+    checkTokenResult.email = token.email,
+    checkTokenResult.name = token.name,
+    checkTokenResult.createdAt = token.createdAt,
+    checkTokenResult.generation = token.generation,
+    checkTokenResult.member = token.member;
 
     return response(baseResponse.SUCCESS, checkTokenResult);
 

--- a/src/app/User/userProvider.js
+++ b/src/app/User/userProvider.js
@@ -22,20 +22,18 @@ exports.emailDuplicateCheck = async function (email) {
   return emailCheckResult;
 }
 
-exports.checkToken = async function(email){
+exports.checkToken = async function(email, exp, iat){
   try{
-    const connection = await pool.getConnection(async (conn) => conn);
-    const checkTokenResult = await userDao.checkToken(connection, email);
-    connection.release();
+    
+    // const connection = await pool.getConnection(async (conn) => conn);
+    // const checkTokenResult = await userDao.checkToken(connection, email);
+    // connection.release();
 
-    const token = jwtDecode(exp);
-    const d = new Date(0);
-    d.setUTCSeconds(token.data.exp);
-    console.log(d)
-    checkTokenResult.expiresIn = d;
+    let checkTokenResult = new Object;
 
-    console.log(checkTokenResult)
-  
+    checkTokenResult.result = "available";
+    checkTokenResult.exp = exp;
+
     return response(baseResponse.SUCCESS, checkTokenResult);
 
   }

--- a/src/app/User/userProvider.js
+++ b/src/app/User/userProvider.js
@@ -1,5 +1,6 @@
 const {logger} = require("../../../config/winston");
 const {pool} = require("../../../config/database");
+var jwtDecode = require('jwt-decode');
 const secret_config = require("../../../config/secret");
 const baseResponse = require("../../../config/baseResponseStatus");
 const {response} = require("../../../config/response");
@@ -26,6 +27,14 @@ exports.checkToken = async function(email){
     const connection = await pool.getConnection(async (conn) => conn);
     const checkTokenResult = await userDao.checkToken(connection, email);
     connection.release();
+
+    const token = jwtDecode(exp);
+    const d = new Date(0);
+    d.setUTCSeconds(token.data.exp);
+    console.log(d)
+    checkTokenResult.expiresIn = d;
+
+    console.log(checkTokenResult)
   
     return response(baseResponse.SUCCESS, checkTokenResult);
 

--- a/src/app/User/userService.js
+++ b/src/app/User/userService.js
@@ -48,7 +48,7 @@ exports.creteUser = async function (name, email, password, member, generation){
             }, // 토큰의 내용(payload)
             secret_config.ACCESSjwtsecret, // 비밀키
             {
-                expiresIn: "3h",
+                expiresIn: "1h",
                 subject: "userInfo",
             } // 유효 기간 365일
         );
@@ -59,7 +59,7 @@ exports.creteUser = async function (name, email, password, member, generation){
             }, // 토큰의 내용(payload)
             secret_config.REFRESHjwtsecret, // 비밀키
             {
-                expiresIn: "6h",
+                expiresIn: "2w",
                 subject: "userInfo",
             } // 유효 기간 365일
         );
@@ -110,7 +110,7 @@ exports.signinUser = async function (email, password)
                 }, // 토큰의 내용(payload)
                 secret_config.ACCESSjwtsecret, // 비밀키
                 {
-                    expiresIn: "3h",
+                    expiresIn: "1h",
                     subject: "userInfo",
                 } // 유효 기간 3시간
             );
@@ -121,7 +121,7 @@ exports.signinUser = async function (email, password)
                 }, // 토큰의 내용(payload)
                 secret_config.REFRESHjwtsecret, // 비밀키
                 {
-                    expiresIn: "6h",
+                    expiresIn: "2w",
                     subject: "userInfo",
                 } // 유효 기간 6시간
             );
@@ -163,7 +163,7 @@ exports.updateToken = async function(refreshToken, email){
                 }, // 토큰의 내용(payload)
                 secret_config.ACCESSjwtsecret, // 비밀키
                 {
-                    expiresIn: "3h",
+                    expiresIn: "1h",
                     subject: "userInfo",
                 } // 유효 기간 3시간
             );
@@ -174,7 +174,7 @@ exports.updateToken = async function(refreshToken, email){
                 }, // 토큰의 내용(payload)
                 secret_config.REFRESHjwtsecret, // 비밀키
                 {
-                    expiresIn: "6h",
+                    expiresIn: "2w",
                     subject: "userInfo",
                 } // 유효 기간 6시간
             );


### PR DESCRIPTION
1. 유저가 로그인 시 Access Token & Refresh Token반환 -> 서버단에서는 DB에 Refresh Token 저장
2. Access Token & Refresh Token 정보 : {[유저 정보], exp}
3. 프론트단에서는 /app/users/auto-login에 Access token을 보내 유저의 정보를 확인하고, 자동 로그인 진행

4. Access Token의 유효기간이 얼마 남지 않았거나 지난 경우 || 잘못된 경우
4-1. local storage에 저장해뒀던 Refresh Token을 /app/users/auto-login/failed에 담아서 전송
4-2. Refresh Token 유효기간이 지나지 않았으면 -> DB에 저장해뒀던 Refresh token과 비교, Access token과 Refresh token을 재발급
4-3. Refresh Token 유효기간이 지났거나 잘못된 토큰이면 -> 재 로그인 요청